### PR TITLE
fix: usePolling에서 렌더링 중 ref를 쓰지 않도록 수정

### DIFF
--- a/src/hooks/usePolling/usePolling.tsx
+++ b/src/hooks/usePolling/usePolling.tsx
@@ -21,7 +21,9 @@ const usePolling = ({
   const retryReference = useRef(0);
   const isUserStoppedRef = useRef(false);
 
-  apiReference.current = apiFunction;
+  useEffect(() => {
+    apiReference.current = apiFunction;
+  }, [apiFunction]);
 
   const clearTimer = () => {
     if (timerReference.current) clearTimeout(timerReference.current);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #8

## 📝 작업 내용

- useEffect로 묶어 렌더링 중 ref를 직접 쓰지 않도록 변경
  - ref를 직접 바꾸는 것은 순수성 혹은 Concurrent 모드에 영향을 미칠 수 있으므로 리액트에서 추천하지 않는 동작방식
