### PR TITLE
fix: 참조 비교를 통해 값이 같은 경우 구독요소를 실행하지 않도록 수정

### DIFF
--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -11,7 +11,17 @@ const createStore = <T>(initialState: T): Store<T> => {
   const getState = () => state;
 
   const setState = (nextState: T | ((previous: T) => T)) => {
-    state = typeof nextState === 'function' ? (nextState as (previous: T) => T)(state) : nextState;
+    const previousState = state;
+
+    const resolvedState =
+      typeof nextState === 'function'
+        ? (nextState as (previous: T) => T)(previousState)
+        : nextState;
+
+    if (Object.is(previousState, resolvedState)) return;
+
+    state = resolvedState;
+
     for (const callback of callbacks) callback();
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #7

## 📝 작업 내용

- `Object.is()`를 이용한 참조 비교를 통해 값이 같은 경우 구독요소를 실행하지 않도록 수정
```ts
const setState = (nextState: T | ((previous: T) => T)) => {
  const previousState = state;

  const resolvedState =
    typeof nextState === 'function'
      ? (nextState as (previous: T) => T)(previousState)
      : nextState;

  // 참조 비교를 통해 같으면 return
  if (Object.is(previousState, resolvedState)) return;

  state = resolvedState;

  for (const callback of callbacks) callback();
};
```
