### PR TITLE
chore: peerDependencies React 18버전으로 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "prepare": "npm run build"
   },
   "peerDependencies": {
-    "react": "^19.2.1",
-    "react-dom": "^19.2.1"
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #15

## 📝 작업 내용

- useStore에서 사용하고 있는 useSyncExternalStore 훅을 사용할 수 있는 최소 버전인 18로 설정
- 이를 통해 최신 버전 이상의 react를 사용하지 않아도(19.2.1) 라이브러리를 사용할 수 있음
